### PR TITLE
DM-25113: Run pipetask in two steps

### DIFF
--- a/bin/pipeline.sh
+++ b/bin/pipeline.sh
@@ -1,9 +1,22 @@
 #!/usr/bin/env sh
+
+set -e
+
 COLLECTION=shared/ci_hsc_output
+INPUTCOLL=calib/hsc,raw/hsc,masks/hsc,ref_cats,skymaps,shared/ci_hsc
 
 export DYLD_LIBRARY_PATH=$LSST_LIBRARY_PATH
 
-pipetask run -d "patch = 69" -j "$1" -b "$2"/butler.yaml \
--i calib/hsc,raw/hsc,masks/hsc,ref_cats,skymaps,shared/ci_hsc -o "$COLLECTION" \
---register-dataset-types \
--p "$CI_HSC_GEN3_DIR"/pipelines/CiHsc.yaml
+# exercise saving of the generated quantum graph to a file and reading it back
+QGRAPH_FILE=$(mktemp)
+trap 'rm -f $QGRAPH_FILE' EXIT
+
+pipetask qgraph -d "patch = 69" -b "$2"/butler.yaml \
+    -i "$INPUTCOLL" -o "$COLLECTION" \
+    -p "$CI_HSC_GEN3_DIR"/pipelines/CiHsc.yaml \
+    --save-qgraph "$QGRAPH_FILE"
+
+pipetask run -j "$1" -b "$2"/butler.yaml \
+    -i "$INPUTCOLL" -o "$COLLECTION" \
+    --register-dataset-types \
+    --qgraph "$QGRAPH_FILE"


### PR DESCRIPTION
`pipeline.sh` script is modified to exercise saving of the quantum graph
to pickle file and reading it back for execution. This seems to be a
useful integration test for functionality that can be broken and other
tests not noticing it.