### PR TITLE
DM-29288: Skip filterlabel correction test if composite is disassembled

### DIFF
--- a/tests/test_filterLabelFixups.py
+++ b/tests/test_filterLabelFixups.py
@@ -133,6 +133,17 @@ class TestFilterLabelFixups(lsst.utils.tests.TestCase):
             visit_system=0,
         )
         self.assertTrue(calexpBadDataId.hasFull())
+
+        # Some tests are only relevant when reading full calexps.
+        # By definition a disassembled exposure will have a correct
+        # filterlabel written out.
+        # In this situation the test becomes moot since the filterLabel
+        # formatter will not force a correct filter label into an
+        # incorrect filter label based on DataId.
+        _, components = self.butler.getURIs("calexp", calexpBadDataId)
+        if components:
+            raise unittest.SkipTest("Test not relevant because composite has been disassembled")
+
         with self.assertWarns(Warning):
             calexp = self.butler.get("calexp", calexpBadDataId)
         with self.assertWarns(Warning):


### PR DESCRIPTION
If we run CI with disassembled composites we know that by definition
the filter label will be written correctly. This makes it hard to
force it to fail by faking a mismatch between data ID and filter
label.

If in the future such a mismatch could occur we would have to
change the FilterLabel formatter to do the same correction
as is done in ExposureFormatter.