### PR TITLE
DM-29196: Use UUID datasets manager as default for ci_hsc_gen3

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -61,8 +61,10 @@ REPO_ROOT = GetOption("root")
 AddOption("--enable-profile", nargs="?", const="profile", dest="enable_profile",
           help=("Profile base filename; output will be <basename>-<sequence#>-<script>.pstats; "
                 "(Note: this option is for profiling the scripts, while --profile is for scons)"))
-AddOption("--butler-config", dest="butler_conf", default="",
-          help="Path to an external Butler config used to create a data repository.")
+AddOption("--butler-config", dest="butler_conf",
+          default=os.path.join(PKG_ROOT, "configs", "butler-seed.yaml"),
+          help=("Path to an external Butler config used to create a data repository. "
+                "Default is configs/registry.yaml"))
 AddOption("--config-override", action="store_true", dest="conf_override",
           help="Override the default config root with the given repo-root.")
 

--- a/configs/butler-seed.yaml
+++ b/configs/butler-seed.yaml
@@ -1,0 +1,3 @@
+registry:
+  managers:
+    datasets: lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManagerUUID


### PR DESCRIPTION
Adds YAML config file used as default value for --butler-config SCons
option, this configures registry to use UUID datasets records manager.