### PR TITLE
DM-29750: Explicitly disable FGCM.

### DIFF
--- a/pipelines/DRP.yaml
+++ b/pipelines/DRP.yaml
@@ -3,6 +3,7 @@ instrument: lsst.obs.subaru.HyperSuprimeCam
 imports:
   location: "${OBS_SUBARU_DIR}/pipelines/DRP.yaml"
   exclude:
+    - fgcm
     # Don't run jointcal here...
     - jointcal
 tasks:


### PR DESCRIPTION
...now that it's enabled upstream in obs_subaru by default.