### PR TITLE
DM-31253: Add support for mock pipeline execution

### DIFF
--- a/bin/pipeline.sh
+++ b/bin/pipeline.sh
@@ -2,6 +2,39 @@
 
 set -e
 
+usage() {
+    cat <<USAGE
+Usage: $0 [-j N] [-m] [-l level] repo
+
+Options:
+    -h          Print usage information.
+    -j N        Run pipetask with N processes, default is 1.
+    -m          Run mock pipeline.
+    -l level    Logging level, default is INFO.
+USAGE
+}
+
+jobs=1
+mock=
+loglevel=INFO
+
+while getopts hj:ml: opt
+do
+    case $opt in
+        h) usage; exit;;
+        j) jobs=$OPTARG;;
+        m) mock="--mock";;
+        l) loglevel=$OPTARG;;
+        \?) usage 1>&2; exit 1;;
+    esac
+done
+shift $((OPTIND - 1))
+if [ $# -eq 0 ]; then
+    usage 1>&2
+    exit 1
+fi
+repo=$1
+
 COLLECTION=HSC/runs/ci_hsc
 INPUTCOLL=HSC/defaults
 FAKES_COLLECTION=HSC/runs/ci_hsc_fakes
@@ -18,39 +51,42 @@ trap 'rm -f $FAKES_QGRAPH_FILE' EXIT
 FARO_QGRAPH_FILE=$(mktemp)_faro.qgraph
 trap 'rm -f $FARO_QGRAPH_FILE' EXIT
 
-pipetask --long-log qgraph \
+pipetask --long-log --log-level="$loglevel" qgraph \
     -d "skymap='discrete/ci_hsc' AND tract=0 AND patch=69" \
-    -b "$2"/butler.yaml \
+    -b "$repo"/butler.yaml \
     --input "$INPUTCOLL" --output "$COLLECTION" \
     -p "$CI_HSC_GEN3_DIR"/pipelines/DRP.yaml \
     --save-qgraph "$QGRAPH_FILE"
 
-pipetask --long-log run -j "$1" -b "$2"/butler.yaml \
+pipetask --long-log --log-level="$loglevel" run \
+    -j "$jobs" -b "$repo"/butler.yaml \
     --input "$INPUTCOLL" --output "$COLLECTION" \
-    --register-dataset-types \
+    --register-dataset-types $mock \
     --qgraph "$QGRAPH_FILE"
 
-pipetask --long-log qgraph \
+pipetask --long-log --log-level="$loglevel" qgraph \
     -d "skymap='discrete/ci_hsc' AND tract=0 AND patch=69" \
-    -b "$2"/butler.yaml \
+    -b "$repo"/butler.yaml \
     --input "$COLLECTION" --output "$FAKES_COLLECTION" \
     -p "$CI_HSC_GEN3_DIR"/pipelines/DRPFakes.yaml \
     --save-qgraph "$FAKES_QGRAPH_FILE"
 
-pipetask --long-log run -j "$1" -b "$2"/butler.yaml \
+pipetask --long-log --log-level="$loglevel" run \
+    -j "$jobs" -b "$repo"/butler.yaml \
     --input "$COLLECTION" --output "$FAKES_COLLECTION" \
-    --register-dataset-types \
+    --register-dataset-types $mock \
     --qgraph "$FAKES_QGRAPH_FILE"
 
-pipetask --long-log qgraph \
+pipetask --long-log --log-level="$loglevel" qgraph \
     -d "skymap='discrete/ci_hsc' AND tract=0 AND patch=69" \
-    -b "$2"/butler.yaml \
+    -b "$repo"/butler.yaml \
     --input "$COLLECTION" --output "$FARO_COLLECTION" \
     -p "$FARO_DIR"/pipelines/metrics_pipeline.yaml \
     --save-qgraph "$FARO_QGRAPH_FILE"
 
-pipetask --long-log run -j "$1" -b "$2"/butler.yaml \
+pipetask --long-log --log-level="$loglevel" run \
+    -j "$jobs" -b "$repo"/butler.yaml \
     --input "$COLLECTION" --output "$FARO_COLLECTION" \
-    --register-dataset-types \
+    --register-dataset-types $mock \
     --qgraph "$FARO_QGRAPH_FILE"
 

--- a/tests/test_filterLabelFixups.py
+++ b/tests/test_filterLabelFixups.py
@@ -66,6 +66,15 @@ class TestFilterLabelFixups(lsst.utils.tests.TestCase):
         # Parameters with bbox to test that logic still works on subimage gets.
         self.parameters = {"bbox": Box2I(Point2I(0, 0), Point2I(8, 7))}
 
+    def _skipMock(self, datasetType="_mock_calexp"):
+        """Skip the test if mock dataset type exists"""
+        try:
+            # if mock dataset type exists then skip the test
+            self.butler.registry.getDatasetType(datasetType)
+            raise unittest.SkipTest("Skipping due to mock dataset type present")
+        except KeyError:
+            pass
+
     def testReadingOldFileWithIncompleteDataId(self):
         """If we try to read an old flat with an incomplete data ID, we should
         get a warning.  It is unspecified what the FilterLabel will have in
@@ -97,6 +106,7 @@ class TestFilterLabelFixups(lsst.utils.tests.TestCase):
         reader should recognize that it can't check the filters and just trust
         the file.
         """
+        self._skipMock()
         calexp = self.butler.get("calexp", self.calexpMinimalDataId)
         calexpFilterLabel = self.butler.get("calexp.filterLabel", self.calexpMinimalDataId)
         self.assertTrue(calexp.getFilterLabel().hasPhysicalLabel())
@@ -110,6 +120,7 @@ class TestFilterLabelFixups(lsst.utils.tests.TestCase):
         should check the filters in the file for consistency with the data ID
         (and in this case, find them consistent).
         """
+        self._skipMock()
         calexpFullDataId = self.butler.registry.expandDataId(self.calexpMinimalDataId)
         calexp = self.butler.get("calexp", calexpFullDataId)
         self.assertEqual(calexp.getFilterLabel().bandLabel, calexpFullDataId["band"])
@@ -126,6 +137,7 @@ class TestFilterLabelFixups(lsst.utils.tests.TestCase):
         (and in this case, find them inconsistent, which should result in
         warnings and returning what's in the data ID).
         """
+        self._skipMock()
         calexpBadDataId = DataCoordinate.standardize(
             self.calexpMinimalDataId,
             band="g",

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -43,6 +43,13 @@ class TestSchemaMatch(lsst.utils.tests.TestCase):
         """Check the schema of the parquet dataset match that in the DDL.
         Only the column names are checked currently.
         """
+        try:
+            # if mock dataset type exists then skip the test
+            self.butler.registry.getDatasetType(f"_mock_{dataset}")
+            raise unittest.SkipTest("Skipping due to mock dataset type present")
+        except KeyError:
+            pass
+
         sdmSchema = [table for table in self.schema if table['name'] == tableName]
         self.assertEqual(len(sdmSchema), 1)
         expectedColumnNames = set(column['name'] for column in sdmSchema[0]['columns'])


### PR DESCRIPTION
`SConstruct` adds a new option `--mock` which passes the same option to `pipetask` commands in `pipeline.sh`.

Also few simple fixes to targets in `SConstruct` to make them match the actual directory tree.
