### PR TITLE
DM-34435: Add support for mock execution to new unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ CALIB
 shared
 gen3.sqlite3
 DATA
+*.pyc

--- a/python/lsst/ci/hsc/gen3/tests/__init__.py
+++ b/python/lsst/ci/hsc/gen3/tests/__init__.py
@@ -1,0 +1,22 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from ._mock import *

--- a/python/lsst/ci/hsc/gen3/tests/_mock.py
+++ b/python/lsst/ci/hsc/gen3/tests/_mock.py
@@ -1,0 +1,88 @@
+# This file is part of ci_hsc_gen3.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Module to support mock option in unit tests.
+"""
+
+__all__ = ["MockCheckMixin"]
+
+from typing import Optional
+import unittest
+
+from lsst.daf.butler import Butler
+
+
+class MockCheckMixin:
+    """Mix-in class to support checking for mock execution."""
+
+    butler: Optional[Butler] = None
+    """Sub-class can define ``butler`` attribute to avoid passing Butler
+    instance to each method."""
+
+    def check_mock(
+        self, dataset_type: str = "calexp", butler: Optional[Butler] = None
+    ) -> bool:
+        """Check whether Butler contents correspond to a mock execution.
+
+        Parameters
+        ----------
+        dataset_type : `str`, optional
+            Name of the dataset that is expected to exist in butler.
+        butler : `Butler`, optional
+            Data butler instance, if `None` then ``self.butler`` must not be
+            `None`.
+
+        Returns
+        -------
+        mock : `bool`
+            True if there is a mock dataset type corresponding to a given type.
+        """
+        if butler is None:
+            butler = self.butler
+        if butler is None:
+            raise ValueError("No butler instance provided")
+        try:
+            # check for mock dataset type
+            butler.registry.getDatasetType(f"_mock_{dataset_type}")
+            return True
+        except KeyError:
+            return False
+
+    def skip_mock(
+        self, dataset_type: str = "calexp", butler: Optional[Butler] = None
+    ) -> None:
+        """Skip a unit test during mock execution.
+
+        Parameters
+        ----------
+        dataset_type : `str`, optional
+            Name of the dataset that is expected to exist in butler.
+        butler : `Butler`, optional
+            Data butler instance, if `None` then ``self.butler`` must not be
+            `None`.
+
+        Raises
+        -------
+        unittest.SkipTest
+            Raised if butler was populated by a mock execution.
+        """
+        if self.check_mock(dataset_type, butler):
+            raise unittest.SkipTest("Skipping due to mock execution")

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -21,15 +21,15 @@
 
 import os
 import unittest
-import numpy as np
 
-from lsst.daf.butler import Butler
 import lsst.utils.tests
-
+import numpy as np
+from lsst.ci.hsc.gen3.tests import MockCheckMixin
+from lsst.daf.butler import Butler
 from lsst.utils import getPackageDir
 
 
-class TestCalibrateOutputs(lsst.utils.tests.TestCase):
+class TestCalibrateOutputs(lsst.utils.tests.TestCase, MockCheckMixin):
     """Test the output data products of calibrate task make sense
 
     This is a regression test and not intended for scientific validation
@@ -38,6 +38,7 @@ class TestCalibrateOutputs(lsst.utils.tests.TestCase):
     def setUp(self):
         self.butler = Butler(os.path.join(getPackageDir("ci_hsc_gen3"), "DATA"),
                              writeable=False, collections=["HSC/runs/ci_hsc"])
+        self.skip_mock()
         self.dataId = {"instrument": "HSC", "detector": 100, "visit": 903334}
         self.calexp = self.butler.get("calexp", self.dataId)
         self.src = self.butler.get("src", self.dataId)

--- a/tests/test_coadd_outputs.py
+++ b/tests/test_coadd_outputs.py
@@ -18,22 +18,22 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import numbers
 import os
 import unittest
-import numbers
-import numpy as np
 
-from lsst.daf.butler import Butler
+import lsst.afw.image
 import lsst.geom as geom
 import lsst.meas.algorithms
-import lsst.afw.image
-
+import numpy as np
+from lsst.ci.hsc.gen3 import DATA_IDS
+from lsst.ci.hsc.gen3.tests import MockCheckMixin
+from lsst.daf.butler import Butler
 from lsst.utils import getPackageDir
 
-from lsst.ci.hsc.gen3 import DATA_IDS
 
-
-class TestCoaddOutputs(unittest.TestCase):
+class TestCoaddOutputs(unittest.TestCase, MockCheckMixin):
     """Check that coadd outputs are as expected.
 
     Many tests here are ported from
@@ -44,7 +44,7 @@ class TestCoaddOutputs(unittest.TestCase):
         self.butler = Butler(os.path.join(getPackageDir("ci_hsc_gen3"), "DATA"),
                              instrument="HSC", skymap="discrete/ci_hsc",
                              writeable=False, collections=["HSC/runs/ci_hsc"])
-
+        self.skip_mock()
         self._tract = 0
         self._patch = 69
         self._bands = ['r', 'i']

--- a/tests/test_filterLabelFixups.py
+++ b/tests/test_filterLabelFixups.py
@@ -22,14 +22,14 @@
 import os
 import unittest
 
-from lsst.geom import Box2I, Point2I
-from lsst.daf.butler import Butler, DataCoordinate
 import lsst.utils.tests
-
+from lsst.ci.hsc.gen3.tests import MockCheckMixin
+from lsst.daf.butler import Butler, DataCoordinate
+from lsst.geom import Box2I, Point2I
 from lsst.utils import getPackageDir
 
 
-class TestFilterLabelFixups(lsst.utils.tests.TestCase):
+class TestFilterLabelFixups(lsst.utils.tests.TestCase, MockCheckMixin):
     """Tests for the logic in
     lsst.obs.base.formatters.fitsExposure.FitsExposureFormatter._fixFilterLabels
     that uses the data ID passed to a formatter to fix and/or check the
@@ -66,15 +66,6 @@ class TestFilterLabelFixups(lsst.utils.tests.TestCase):
         # Parameters with bbox to test that logic still works on subimage gets.
         self.parameters = {"bbox": Box2I(Point2I(0, 0), Point2I(8, 7))}
 
-    def _skipMock(self, datasetType="_mock_calexp"):
-        """Skip the test if mock dataset type exists"""
-        try:
-            # if mock dataset type exists then skip the test
-            self.butler.registry.getDatasetType(datasetType)
-            raise unittest.SkipTest("Skipping due to mock dataset type present")
-        except KeyError:
-            pass
-
     def testReadingOldFileWithIncompleteDataId(self):
         """If we try to read an old flat with an incomplete data ID, we should
         get a warning.  It is unspecified what the FilterLabel will have in
@@ -106,7 +97,7 @@ class TestFilterLabelFixups(lsst.utils.tests.TestCase):
         reader should recognize that it can't check the filters and just trust
         the file.
         """
-        self._skipMock()
+        self.skip_mock()
         calexp = self.butler.get("calexp", self.calexpMinimalDataId)
         calexpFilterLabel = self.butler.get("calexp.filterLabel", self.calexpMinimalDataId)
         self.assertTrue(calexp.getFilterLabel().hasPhysicalLabel())
@@ -120,7 +111,7 @@ class TestFilterLabelFixups(lsst.utils.tests.TestCase):
         should check the filters in the file for consistency with the data ID
         (and in this case, find them consistent).
         """
-        self._skipMock()
+        self.skip_mock()
         calexpFullDataId = self.butler.registry.expandDataId(self.calexpMinimalDataId)
         calexp = self.butler.get("calexp", calexpFullDataId)
         self.assertEqual(calexp.getFilterLabel().bandLabel, calexpFullDataId["band"])
@@ -137,7 +128,7 @@ class TestFilterLabelFixups(lsst.utils.tests.TestCase):
         (and in this case, find them inconsistent, which should result in
         warnings and returning what's in the data ID).
         """
-        self._skipMock()
+        self.skip_mock()
         calexpBadDataId = DataCoordinate.standardize(
             self.calexpMinimalDataId,
             band="g",

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -21,15 +21,15 @@
 
 import os
 import unittest
-import yaml
 
-from lsst.daf.butler import Butler
 import lsst.utils.tests
-
+import yaml
+from lsst.ci.hsc.gen3.tests import MockCheckMixin
+from lsst.daf.butler import Butler
 from lsst.utils import getPackageDir
 
 
-class TestSchemaMatch(lsst.utils.tests.TestCase):
+class TestSchemaMatch(lsst.utils.tests.TestCase, MockCheckMixin):
     """Check the schema of the parquet outputs match the DDL in sdm_schemas"""
 
     def setUp(self):
@@ -43,12 +43,8 @@ class TestSchemaMatch(lsst.utils.tests.TestCase):
         """Check the schema of the parquet dataset match that in the DDL.
         Only the column names are checked currently.
         """
-        try:
-            # if mock dataset type exists then skip the test
-            self.butler.registry.getDatasetType(f"_mock_{dataset}")
-            raise unittest.SkipTest("Skipping due to mock dataset type present")
-        except KeyError:
-            pass
+        # skip the test in mock execution
+        self.skip_mock(dataset)
 
         sdmSchema = [table for table in self.schema if table['name'] == tableName]
         self.assertEqual(len(sdmSchema), 1)

--- a/tests/test_validate_outputs.py
+++ b/tests/test_validate_outputs.py
@@ -21,14 +21,13 @@
 import os
 import unittest
 
+from lsst.ci.hsc.gen3 import DATA_IDS
+from lsst.ci.hsc.gen3.tests import MockCheckMixin
 from lsst.daf.butler import Butler
-
 from lsst.utils import getPackageDir
 
-from lsst.ci.hsc.gen3 import DATA_IDS
 
-
-class TestValidateOutputs(unittest.TestCase):
+class TestValidateOutputs(unittest.TestCase, MockCheckMixin):
     """Check that ci_hsc_gen3 outputs are as expected."""
 
     def setUp(self):
@@ -76,6 +75,9 @@ class TestValidateOutputs(unittest.TestCase):
             Additional keywords to send to ``additional_checks``.
         """
         for dataset_type in dataset_types:
+
+            self.skip_mock(dataset_type)
+
             datasets = set(self.butler.registry.queryDatasets(dataset_type))
 
             self.assertEqual(len(datasets), n_expected, msg=f"Number of {dataset_type}")
@@ -106,6 +108,9 @@ class TestValidateOutputs(unittest.TestCase):
             Additional keywords to send to ``additional_checks``.
         """
         for source_dataset_type in source_dataset_types:
+
+            self.skip_mock(source_dataset_type)
+
             datasets = set(self.butler.registry.queryDatasets(source_dataset_type))
 
             self.assertEqual(len(datasets), n_expected, msg=f"Number of {source_dataset_type}")


### PR DESCRIPTION
Added simple helper methods to identify mock execution and updated unit
tests to use those methods. Also ran `isort` on few files that I touched.