### PR TITLE
DM-34455: Ask datastore whether the dataset exists

### DIFF
--- a/tests/test_validate_outputs.py
+++ b/tests/test_validate_outputs.py
@@ -83,7 +83,7 @@ class TestValidateOutputs(unittest.TestCase, MockCheckMixin):
             self.assertEqual(len(datasets), n_expected, msg=f"Number of {dataset_type}")
 
             for dataset in datasets:
-                self.assertTrue(self.butler.getURI(dataset).exists(), msg=f"File exists for {dataset}")
+                self.assertTrue(self.butler.datastore.exists(dataset), msg=f"File exists for {dataset}")
 
                 if additional_checks:
                     data = self.butler.getDirect(dataset)


### PR DESCRIPTION
getURI is not reliable with disassembled composites and
it's better to ask the datastore directly whether it has the
artifact.