### PR TITLE
DM-33959: Rename writeSourceTable to writeRecalibratedSourceTable

### DIFF
--- a/tests/test_validate_outputs.py
+++ b/tests/test_validate_outputs.py
@@ -149,7 +149,7 @@ class TestValidateOutputs(unittest.TestCase, MockCheckMixin):
     def test_source_tables(self):
         """Test existence of source tables."""
         self.check_pipetasks(
-            ["writeSourceTable", "transformSourceTable"],
+            ["writeRecalibratedSourceTable", "transformSourceTable"],
             self._num_exposures,
             self._num_exposures
         )


### PR DESCRIPTION
The task dimensions gained a skymap and can no longer
use the same label