### PR TITLE
DM-38210: Use butler.get() rather than deprecated getDirect()

### DIFF
--- a/tests/test_coadd_outputs.py
+++ b/tests/test_coadd_outputs.py
@@ -190,7 +190,7 @@ class TestCoaddOutputs(unittest.TestCase, MockCheckMixin):
             # We only need to test one dataset
             dataset = list(datasets)[0]
 
-            warp = self.butler.getDirect(dataset)
+            warp = self.butler.get(dataset)
             self.assertEqual(warp.wcs, tract_info.wcs)
             coadd_inputs = warp.getInfo().getCoaddInputs()
             self.assertEqual(len(coadd_inputs.visits), 1)

--- a/tests/test_hips_outputs.py
+++ b/tests/test_hips_outputs.py
@@ -50,7 +50,7 @@ class TestHipsOutputs(unittest.TestCase, MockCheckMixin):
             for dataset in datasets:
                 self.assertTrue(self.butler.datastore.exists(dataset), msg="File exists for deepCoadd_hpx")
 
-            exp = self.butler.getDirect(list(datasets)[0])
+            exp = self.butler.get(list(datasets)[0])
 
             self.assertEqual(exp.wcs.getFitsMetadata()["CTYPE1"], "RA---HPX")
             self.assertEqual(exp.wcs.getFitsMetadata()["CTYPE2"], "DEC--HPX")

--- a/tests/test_validate_outputs.py
+++ b/tests/test_validate_outputs.py
@@ -87,7 +87,7 @@ class TestValidateOutputs(unittest.TestCase, MockCheckMixin):
                 self.assertTrue(self.butler.datastore.exists(dataset), msg=f"File exists for {dataset}")
 
                 if additional_checks:
-                    data = self.butler.getDirect(dataset)
+                    data = self.butler.get(dataset)
                     for additional_check in additional_checks:
                         additional_check(data, **kwargs)
 
@@ -117,7 +117,7 @@ class TestValidateOutputs(unittest.TestCase, MockCheckMixin):
             self.assertEqual(len(datasets), n_expected, msg=f"Number of {source_dataset_type}")
 
             for dataset in datasets:
-                catalog = self.butler.getDirect(dataset)
+                catalog = self.butler.get(dataset)
                 self.assertGreater(len(catalog), min_src, msg=f"Number of sources in {dataset}")
 
                 for additional_check in additional_checks:


### PR DESCRIPTION
Requires lsst/daf_butler#797