### PR TITLE
DM-39122: Pass output run to `GraphBuilder.makeGraph` to suppress warnings

### DIFF
--- a/bin/pipeline.sh
+++ b/bin/pipeline.sh
@@ -45,19 +45,12 @@ HIPS_COLLECTION=HSC/runs/ci_hsc_hips
 export DYLD_LIBRARY_PATH="$LSST_LIBRARY_PATH"
 # exercise saving of the generated quantum graph to a file and reading it back
 QGRAPH_FILE=$(mktemp).qgraph
-trap 'rm -f $QGRAPH_FILE' EXIT
-
 FAKES_QGRAPH_FILE=$(mktemp)_fakes.qgraph
-trap 'rm -f $FAKES_QGRAPH_FILE' EXIT
-
 FARO_QGRAPH_FILE=$(mktemp)_faro.qgraph
-trap 'rm -f $FARO_QGRAPH_FILE' EXIT
-
 RESOURCE_USAGE_QGRAPH_FILE=$(mktemp)_resource_usage.qgraph
-trap 'rm -f $RESOURCE_USAGE_QGRAPH_FILE' EXIT
-
 HIPS_QGRAPH_FILE=$(mktemp)_hips.qgraph
-trap 'rm -f $HIPS_QGRAPH_FILE' EXIT
+
+trap 'rm -f $QGRAPH_FILE $FAKES_QGRAPH_FILE $FARO_QGRAPH_FILE $RESOURCE_USAGE_QGRAPH_FILE $HIPS_QGRAPH_FILE' EXIT
 
 pipetask --long-log --log-level="$loglevel" qgraph \
     -d "skymap='discrete/ci_hsc' AND tract=0 AND patch=69" \

--- a/tests/test_lookupFunction.py
+++ b/tests/test_lookupFunction.py
@@ -74,7 +74,7 @@ class PrerequisiteConnectionLookupFunctionTest(unittest.TestCase):
         pipeline.addTask(LookupTestPipelineTask, "test")
 
         graphBuilder = pipeBase.GraphBuilder(butler.registry)
-        graph = graphBuilder.makeGraph(pipeline, ["HSC/calib"], None, None)
+        graph = graphBuilder.makeGraph(pipeline, ["HSC/calib"], "output/run", None)
         outputs = list(graph)
         # verify the graph contains no datasetRefs for brighter fatter kernels
         # instead of the datasetRefs that exist in the registry.


### PR DESCRIPTION
This also updates `pipeline.sh` trap-EXIT command to delete all temporary files, there can only be one trap command per signal.