### PR TITLE
DM-37704: Update dataset IDs in export file

### DIFF
--- a/resources/external_jointcal.yaml
+++ b/resources/external_jointcal.yaml
@@ -133,7 +133,7 @@ data:
   run: HSC/external
   records:
   - dataset_id:
-    - 10000
+    - 20000
     data_id:
     - instrument: HSC
       skymap: discrete/ci_hsc
@@ -142,7 +142,7 @@ data:
     path: jointcal/jointcal_wcsCatalog-0903334.fits
     formatter: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
   - dataset_id:
-    - 10002
+    - 20002
     data_id:
     - instrument: HSC
       skymap: discrete/ci_hsc
@@ -151,7 +151,7 @@ data:
     path: jointcal/jointcal_wcsCatalog-0903336.fits
     formatter: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
   - dataset_id:
-    - 10004
+    - 20004
     data_id:
     - instrument: HSC
       skymap: discrete/ci_hsc
@@ -160,7 +160,7 @@ data:
     path: jointcal/jointcal_wcsCatalog-0903338.fits
     formatter: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
   - dataset_id:
-    - 10006
+    - 20006
     data_id:
     - instrument: HSC
       skymap: discrete/ci_hsc
@@ -169,7 +169,7 @@ data:
     path: jointcal/jointcal_wcsCatalog-0903342.fits
     formatter: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
   - dataset_id:
-    - 10008
+    - 20008
     data_id:
     - instrument: HSC
       skymap: discrete/ci_hsc
@@ -178,7 +178,7 @@ data:
     path: jointcal/jointcal_wcsCatalog-0903344.fits
     formatter: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
   - dataset_id:
-    - 10010
+    - 20010
     data_id:
     - instrument: HSC
       skymap: discrete/ci_hsc
@@ -187,7 +187,7 @@ data:
     path: jointcal/jointcal_wcsCatalog-0903346.fits
     formatter: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
   - dataset_id:
-    - 10012
+    - 20012
     data_id:
     - instrument: HSC
       skymap: discrete/ci_hsc
@@ -196,7 +196,7 @@ data:
     path: jointcal/jointcal_wcsCatalog-0903986.fits
     formatter: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
   - dataset_id:
-    - 10014
+    - 20014
     data_id:
     - instrument: HSC
       skymap: discrete/ci_hsc
@@ -205,7 +205,7 @@ data:
     path: jointcal/jointcal_wcsCatalog-0903988.fits
     formatter: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
   - dataset_id:
-    - 10016
+    - 20016
     data_id:
     - instrument: HSC
       skymap: discrete/ci_hsc
@@ -214,7 +214,7 @@ data:
     path: jointcal/jointcal_wcsCatalog-0903990.fits
     formatter: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
   - dataset_id:
-    - 10018
+    - 20018
     data_id:
     - instrument: HSC
       skymap: discrete/ci_hsc
@@ -223,7 +223,7 @@ data:
     path: jointcal/jointcal_wcsCatalog-0904010.fits
     formatter: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
   - dataset_id:
-    - 10020
+    - 20020
     data_id:
     - instrument: HSC
       skymap: discrete/ci_hsc


### PR DESCRIPTION
`external_jointcal.yaml` dataset IDs were non-unique, which caused issues with always-resolved refs.