### PR TITLE
DM-38498: Add band constraint to faro --data-query argument.

### DIFF
--- a/bin/pipeline.sh
+++ b/bin/pipeline.sh
@@ -68,7 +68,7 @@ pipetask --long-log --log-level="$loglevel" run \
     --qgraph "$QGRAPH_FILE"
 
 pipetask --long-log --log-level="$loglevel" qgraph \
-    -d "skymap='discrete/ci_hsc' AND tract=0 AND patch=69" \
+    -d "skymap='discrete/ci_hsc' AND tract=0 AND patch=69 AND band in ('r', 'i')" \
     -b "$repo"/butler.yaml \
     --input "$COLLECTION" --output "$FARO_COLLECTION" \
     -p "$FARO_DIR"/pipelines/metrics_pipeline.yaml \


### PR DESCRIPTION
When a task has band in its quantum dimensions but does not have band in the dimensions of any of its inputs, it will run over all bands known to any instrument unless those bands are constrained by the data query.  It was an accident of the old QG generation algorithm that this wasn't happening before (unrelated tasks in the same step were providing a band constraint, but the middleware now sees them as unrelated).