### PR TITLE
DM-42636: Add day_obs to data ID when standardizing

### DIFF
--- a/tests/test_filterLabelFixups.py
+++ b/tests/test_filterLabelFixups.py
@@ -133,7 +133,7 @@ class TestFilterLabelFixups(lsst.utils.tests.TestCase, MockCheckMixin):
             self.calexpMinimalDataId,
             band="g",
             physical_filter="HSC-G",
-            visit_system=0,
+            day_obs=20240101,
         )
         self.assertTrue(calexpBadDataId.hasFull())
 


### PR DESCRIPTION
Remove visit_system since it is no longer needed. Without day_obs the physical_filter and band are ignored.