### PR TITLE
DM-49372: Stop testing 'source' quantities.

### DIFF
--- a/tests/test_astrometryFail.py
+++ b/tests/test_astrometryFail.py
@@ -71,13 +71,13 @@ class TestAstrometryFails(lsst.utils.tests.TestCase):
         successfully "reevaluated" if the associated calibration does indeed
         exist (this is to allow for the external calibrations to potentially
         "recover" from a failed SFM astrometric fit).  In this case, those
-        files do indeed exist in the ci_hsc_gen3 repo, so the ``source`` and
-        ``sourceTable`` catalogs will have valid coord entries.
+        files do indeed exist in the ci_hsc_gen3 repo, so the ``sourceTable``
+        catalogs will have valid coord entries.
         """
         sourceCat = self.butler.get("src", self.calexpMinimalDataId)
         self.assertTrue(np.all(np.isnan(sourceCat["coord_ra"])))
         self.assertTrue(np.all(np.isnan(sourceCat["coord_dec"])))
-        for catStr in ["source", "sourceTable"]:
+        for catStr in ["sourceTable"]:
             sourceCat = self.butler.get(catStr, self.calexpMinimalDataId)
             self.assertFalse(np.all(np.isnan(sourceCat["coord_ra"])))
             self.assertFalse(np.all(np.isnan(sourceCat["coord_dec"])))


### PR DESCRIPTION
The tests on other single-visit catalogs are plenty sufficient, and we probably want to move these tests in the direction of only paying attention to final outputs, not intermediates.